### PR TITLE
Fix #46 IE10 default locale, README HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Did this plugin help you out? Support open source development! <a href="https://
 
 ##Changelog
 
-🆕 v 2.2.0 - A good deal of edits (see details <a href="https://github.com/kthornbloom/Monthly/pull/41">here</a>) including localization, code cleanup & json events. <b>A big thank you to <a href="https://github.com/richardtallent">Richard Tallent</b> for this one!
+🆕 v 2.2.0 - A good deal of edits (see details <a href="https://github.com/kthornbloom/Monthly/pull/41">here</a>) including localization, code cleanup & json events. <b>A big thank you to <a href="https://github.com/richardtallent">Richard Tallent</a> for this one!
 
 v 2.1.0 - Fixed a bug where the event list would animate <i>in</i> but not <i>out</i>. Merged a pull request to include json support. (Thanks marekstodolny!) Made buttons more visible in header for closing event list & reverting to the current month.
 

--- a/js/monthly.js
+++ b/js/monthly.js
@@ -318,7 +318,10 @@ Monthly 2.2.0 by Kevin Thornbloom is licensed under a Creative Commons Attributi
 
 		// Detect the user's preferred language
 		function defaultLocale() {
-			return navigator.languages && navigator.languages.length ? navigator.languages[0] : navigator.language;
+			if(navigator.languages && navigator.languages.length) {
+				return navigator.languages[0];
+			}
+			return navigator.language || navigator.browserLanguage;
 		}
 
 		// Use the user's locale if possible to obtain a list of short month names, falling back on English


### PR DESCRIPTION
This should fix #46, though I don't have IE10 to test the fix. Also fixes a README closing tag issue.