### PR TITLE
Fixed bug with events displaying on the wrong month when clicking the next or previous month buttons rapidly

### DIFF
--- a/js/monthly.js
+++ b/js/monthly.js
@@ -279,14 +279,16 @@ Monthly 2.2.0 by Kevin Thornbloom is licensed under a Creative Commons Attributi
 		}
 
 		function addEventsFromString(events, setMonth, setYear) {
-			if (options.dataType === "xml") {
-				$(events).find("event").each(function(index, event) {
-					addEvent(event, setMonth, setYear);
-				});
-			} else if (options.dataType === "json") {
-				$.each(events.monthly, function(index, event) {
-					addEvent(event, setMonth, setYear);
-				});
+			if ($(parent).data("setMonth") == setMonth && $(parent).data("setYear") == setYear) {
+				if (options.dataType === "xml") {
+					$(events).find("event").each(function(index, event) {
+						addEvent(event, setMonth, setYear);
+					});
+				} else if (options.dataType === "json") {
+					$.each(events.monthly, function(index, event) {
+						addEvent(event, setMonth, setYear);
+					});
+				}
 			}
 		}
 


### PR DESCRIPTION
If Monthly.js is set up to load its events from a URL, and the user rapidly clicks the next or previous month buttons, then the events from multiple months will sometimes display all together on one month. This is especially noticeable if the server is slow at generating the XML/JSON, or if the user has a slow connection.

This change fixes the bug by only adding events that are for the current month and year.