### PR TITLE
Fix readme tag, add dtYYYY-MM-DD class to days

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Did this plugin help you out? Support open source development! <a href="https://
 
 ##Changelog
 
-🆕 v 2.2.0 - A good deal of edits (see details <a href="https://github.com/kthornbloom/Monthly/pull/41">here</a>) including localization, code cleanup & json events. <b>A big thank you to <a href="https://github.com/richardtallent">Richard Tallent</a> for this one!
+🆕 v 2.2.0 - A good deal of edits (see details <a href="https://github.com/kthornbloom/Monthly/pull/41">here</a>) including localization, code cleanup & json events. <b>A big thank you to <a href="https://github.com/richardtallent">Richard Tallent</a> for this one!</b>
 
 v 2.1.0 - Fixed a bug where the event list would animate <i>in</i> but not <i>out</i>. Merged a pull request to include json support. (Thanks marekstodolny!) Made buttons more visible in header for closing event list & reverting to the current month.
 

--- a/js/monthly.js
+++ b/js/monthly.js
@@ -113,16 +113,19 @@ Monthly 2.2.0 by Kevin Thornbloom is licensed under a Creative Commons Attributi
 					))),
 					innerMarkup = '<div class="monthly-day-number">' + dayNumber + '</div><div class="monthly-indicator-wrap"></div>';
 				if(options.mode === "event") {
-					var dayOfWeek = new Date(year, mZeroed, dayNumber, 0, 0, 0, 0).getDay();
+					var thisDate = new Date(year, mZeroed, dayNumber, 0, 0, 0, 0);
 					$(parent + " .monthly-day-wrap").append("<div"
-						+ attr("class", "m-d monthly-day monthly-day-event" + (isInPast ? " monthly-past-day" : ""))
+						+ attr("class", "m-d monthly-day monthly-day-event"
+							+ (isInPast ? " monthly-past-day" : "")
+							+ " dt" + thisDate.toISOString().slice(0, 10)
+							)
 						+ attr("data-number", dayNumber)
 						+ ">" + innerMarkup + "</div>");
 					$(parent + " .monthly-event-list").append("<div"
 						+ attr("class", "monthly-list-item")
 						+ attr("id", uniqueId + "day" + dayNumber)
 						+ attr("data-number", dayNumber)
-						+ '><div class="monthly-event-list-date">' + dayNames[dayOfWeek] + "<br>" + dayNumber + "</div></div>");
+						+ '><div class="monthly-event-list-date">' + dayNames[thisDate.getDay()] + "<br>" + dayNumber + "</div></div>");
 				} else {
 					$(parent + " .monthly-day-wrap").append("<a"
 						+ attr("href", "#")


### PR DESCRIPTION
This is partially in response to #51. By adding a class to each day block corresponding with the actual date, it would be trivial to include CSS that identifies holidays and changes the formatting of the dates for those holidays.