### PR TITLE
Added LICENSE.txt containing the license statement from monthly.js

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,3 @@
+Monthly 2.2.1 by Kevin Thornbloom is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License.
+
+https://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
Added a LICENSE.txt file so the terms are easier to find.  I just copied the license statement from js/monthly.js and added a link to the full text of the license as creativecommons.org recommends.