### PR TITLE
New description tag

### DIFF
--- a/css/monthly.css
+++ b/css/monthly.css
@@ -345,7 +345,7 @@
 }
 
 .monthly-list-time-start,
-.monthly-list-time-end {
+.monthly-list-time-end .monthly-list-description {
 	font-size: .8em;
 	display: inline-block;
 }

--- a/events.xml
+++ b/events.xml
@@ -15,14 +15,71 @@
 
 	<event>
 		<id>2</id>
-		<name>Another Event</name>
-		<startdate>2017-1-10</startdate>
-		<enddate></enddate>
-		<starttime></starttime>
-		<endtime></endtime>
-		<color>#28cbff</color>
-		<url></url>
-	</event>
+        <name>XML Events</name>
+        <startdate>2018-6-12</startdate>
+        <enddate>2018-6-15</enddate>
+        <description>
+			<![CDATA[ 
+			    <style>
+			    table {
+			        font-family: arial, sans-serif;
+			        border-collapse: collapse;
+			        width: 100%;
+			    }
+
+			    td, th {
+			        border: 1px solid #dddddd;
+			        text-align: left;
+			        padding: 8px;
+			    }
+
+			    tr:nth-child(even) {
+			        background-color: #dddddd;
+			    }
+			    </style>
+			    <table>
+			      <tr>
+			        <th>Company</th>
+			        <th>Contact</th>
+			        <th>Country</th>
+			      </tr>
+			      <tr>
+			        <td>Alfreds Futterkiste</td>
+			        <td>Maria Anders</td>
+			        <td>Germany</td>
+			      </tr>
+			      <tr>
+			        <td>Centro comercial Moctezuma</td>
+			        <td>Francisco Chang</td>
+			        <td>Mexico</td>
+			      </tr>
+			      <tr>
+			        <td>Ernst Handel</td>
+			        <td>Roland Mendel</td>
+			        <td>Austria</td>
+			      </tr>
+			      <tr>
+			        <td>Island Trading</td>
+			        <td>Helen Bennett</td>
+			        <td>UK</td>
+			      </tr>
+			      <tr>
+			        <td>Laughing Bacchus Winecellars</td>
+			        <td>Yoshi Tannamuri</td>
+			        <td>Canada</td>
+			      </tr>
+			      <tr>
+			        <td>Magazzini Alimentari Riuniti</td>
+			        <td>Giovanni Rovelli</td>
+			        <td>Italy</td>
+			      </tr>
+			    </table>
+			]]>
+        </description>
+        <starttime>12:00</starttime>
+		<endtime>2:00</endtime>
+        <color>#ffb128</color>
+    </event>
 
 	<event>
 		<id>3</id>
@@ -65,6 +122,17 @@
 		<starttime></starttime>
 		<endtime></endtime>
 		<color>#9f4b99</color>
+		<url></url>
+	</event>
+
+	<event>
+		<id>7</id>
+		<name>XML Events</name>
+		<startdate>2018-6-5</startdate>
+		<starttime>12:00</starttime>
+		<endtime>2:00</endtime>
+		<description>This is a description of the event</description>
+		<color>#ffb128</color>
 		<url></url>
 	</event>
 

--- a/js/monthly.js
+++ b/js/monthly.js
@@ -249,7 +249,7 @@ Monthly 2.2.2 by Kevin Thornbloom is licensed under a Creative Commons Attributi
 					+ attr("data-eventid", eventId)
 					+ (eventColor ? attr("style", "background:" + eventColor) : "")
 					+ attr("title", eventTitle)
-					+ ">" + eventTitle + " " + "</br>" + descriptionHtml + timeHtml + "</a>";
+					+ ">" + eventTitle + " " + "</br>" + (descriptionHtml? descriptionHtml : "" ) + timeHtml + "</a>";
 			for(var index = startDayNumber; index <= endDayNumber; index++) {
 				var doShowTitle = index === showEventTitleOnDay;
 				// Add to calendar view
@@ -259,7 +259,7 @@ Monthly 2.2.2 by Kevin Thornbloom is licensed under a Creative Commons Attributi
 							// Include a class marking if this event continues from the previous day
 							+ (doShowTitle ? "" : " monthly-event-continued")
 							)
-						+ "><span>" + (doShowTitle ? eventTitle : "") + dayEndTags);
+						+ "><span>" + eventTitle + dayEndTags);
 				// Add to event list
 				$(parent + ' .monthly-list-item[data-number="' + index + '"]')
 					.addClass("item-has-event")

--- a/js/monthly.js
+++ b/js/monthly.js
@@ -213,6 +213,7 @@ Monthly 2.2.2 by Kevin Thornbloom is licensed under a Creative Commons Attributi
 				timeHtml = "",
 				eventURL = _getEventDetail(event, "url"),
 				eventTitle = _getEventDetail(event, "name"),
+				eventDescription = _getEventDetail(event, "description"),
 				eventClass = _getEventDetail(event, "class"),
 				eventColor = _getEventDetail(event, "color"),
 				eventId = _getEventDetail(event, "id"),
@@ -225,6 +226,11 @@ Monthly 2.2.2 by Kevin Thornbloom is licensed under a Creative Commons Attributi
 				timeHtml = '<div><div class="monthly-list-time-start">' + formatTime(startTime) + "</div>"
 					+ (endTime ? '<div class="monthly-list-time-end">' + formatTime(endTime) + "</div>" : "")
 					+ "</div>";
+			}
+
+			if(eventDescription) {
+				var descriptionHtml = '';
+				descriptionHtml = '<div><div class="monthly-list-description">' + eventDescription + "</div>" + "</div>";
 			}
 
 			if(options.linkCalendarToEventUrl && eventURL) {
@@ -243,7 +249,7 @@ Monthly 2.2.2 by Kevin Thornbloom is licensed under a Creative Commons Attributi
 					+ attr("data-eventid", eventId)
 					+ (eventColor ? attr("style", "background:" + eventColor) : "")
 					+ attr("title", eventTitle)
-					+ ">" + eventTitle + " " + timeHtml + "</a>";
+					+ ">" + eventTitle + " " + "</br>" + descriptionHtml + timeHtml + "</a>";
 			for(var index = startDayNumber; index <= endDayNumber; index++) {
 				var doShowTitle = index === showEventTitleOnDay;
 				// Add to calendar view


### PR DESCRIPTION
I was using this plugin and I notice that I can't put a title of the event and then a description that I could see only when I clicked on the event.
I added this funcionatily so the user can have a little more customization, having an option to add the name to the event and if they wanted to add more details they could use a tag.
I wanted the user to have more information about how can they customize that description tag so I also added one example where I add an HTML table in the description of the event.